### PR TITLE
fix: correct llm-agents.nix repo URL in example flake

### DIFF
--- a/examples/flake.nix
+++ b/examples/flake.nix
@@ -12,7 +12,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     llm-agents = {
-      url = "github:asheshgoplani/llm-agents.nix";
+      url = "github:numtide/llm-agents.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
## Summary
- Fix incorrect repository URL in `examples/flake.nix`: changed `github:asheshgoplani/llm-agents.nix` to `github:numtide/llm-agents.nix`
- The llm-agents.nix package is maintained by numtide, not asheshgoplani

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)